### PR TITLE
Fix dependency vulnerabilities

### DIFF
--- a/static/package.json
+++ b/static/package.json
@@ -29,7 +29,7 @@
     "stylus-loader": "^1.5.1",
     "url-loader": "^0.5.7",
     "webpack": "1.12.1",
-    "webpack-dev-server": "1.10.1"
+    "webpack-dev-server": ">=3.1.11"
   },
   "dependencies": {
     "detect-browser": "^1.3.1",
@@ -39,6 +39,6 @@
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-tooltip": "^1.1.4",
-    "superagent": "^1.8.2"
+    "superagent": "^5.2.1"
   }
 }


### PR DESCRIPTION
Updated package.json to upgrade `webpack-dev-server` and `superagent` that fixes  CVE-2018-14732 and CVE-2017-16129.