### PR TITLE
Switch queue package to use npm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.18.2",
         "express-validator": "^6.15.0",
         "libsodium-wrappers": "^0.7.11",
-        "queue": "github:jessetane/queue#d189671630450c7dc33eb6ce16988808ef1d3b80",
+        "queue": "^7.0.0",
         "tslog": "^4.8.2",
         "unicode-emoji": "^2.4.0"
       },
@@ -2668,10 +2668,9 @@
       }
     },
     "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "git+ssh://git@github.com/jessetane/queue.git#d189671630450c7dc33eb6ce16988808ef1d3b80",
-      "integrity": "sha512-qZy5iQ5OwDnfC7j5iCjEcDj2Acjy3KLlAEjXBOEgKNZWLp5tge0E7FK7KySmzT1aai3mDgbC+8RJLbqWyDIrkA==",
-      "license": "MIT"
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-7.0.0.tgz",
+      "integrity": "sha512-sphwS7HdfQnvrJAXUNAUgpf9H/546IE3p/5Lf2jr71O4udEYlqAhkevykumas2FYuMkX/29JMOgrRdRoYZ/X9w=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5227,9 +5226,9 @@
       }
     },
     "queue": {
-      "version": "git+ssh://git@github.com/jessetane/queue.git#d189671630450c7dc33eb6ce16988808ef1d3b80",
-      "integrity": "sha512-qZy5iQ5OwDnfC7j5iCjEcDj2Acjy3KLlAEjXBOEgKNZWLp5tge0E7FK7KySmzT1aai3mDgbC+8RJLbqWyDIrkA==",
-      "from": "queue@github:jessetane/queue#d189671630450c7dc33eb6ce16988808ef1d3b80"
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-7.0.0.tgz",
+      "integrity": "sha512-sphwS7HdfQnvrJAXUNAUgpf9H/546IE3p/5Lf2jr71O4udEYlqAhkevykumas2FYuMkX/29JMOgrRdRoYZ/X9w=="
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/bot/package.json
+++ b/bot/package.json
@@ -35,7 +35,7 @@
     "express": "^4.18.2",
     "express-validator": "^6.15.0",
     "libsodium-wrappers": "^0.7.11",
-    "queue": "github:jessetane/queue#d189671630450c7dc33eb6ce16988808ef1d3b80",
+    "queue": "^7.0.0",
     "tslog": "^4.8.2",
     "unicode-emoji": "^2.4.0"
   },


### PR DESCRIPTION
The package update has been released on npm, so I am switching back to it.