### PR TITLE
Update ShareStore.ts

### DIFF
--- a/website/src/stores/ShareStore.ts
+++ b/website/src/stores/ShareStore.ts
@@ -3,6 +3,13 @@ import dispatcher from '../dispatcher';
 import Constants from '../Constants';
 
 class ShareStore extends EventEmitter {
+  constructor() {
+    super();
+    this.shareWithFacebook = this.shareWithFacebook.bind(this);
+    this.shareWithTwitter = this.shareWithTwitter.bind(this);
+    this.open = this.open.bind(this);
+  }
+
   shareWithFacebook() {
     this.open(Constants.Social.URL_FACEBOOK);
   }
@@ -11,26 +18,25 @@ class ShareStore extends EventEmitter {
     this.open(Constants.Social.URL_TWITTER);
   }
 
-  open(url: string) {
+  open(url) {
     window.open(url, '', 'height=500, width=500');
   }
 
-  handle({ type }) {
-    switch (type) {
-      case Constants.Event.SHARE_WITH_FACEBOOK: {
+  handleAction(action) {
+    switch (action.type) {
+      case Constants.Event.SHARE_WITH_FACEBOOK:
         this.shareWithFacebook();
         break;
-      }
-      case Constants.Event.SHARE_WITH_TWITTER: {
+      case Constants.Event.SHARE_WITH_TWITTER:
         this.shareWithTwitter();
         break;
-      }
+      default:
+        break;
     }
   }
 }
 
 const shareStore = new ShareStore();
-
-dispatcher.subscribe(shareStore.handle.bind(shareStore));
+dispatcher.register(shareStore.handleAction.bind(shareStore));
 
 export default shareStore;


### PR DESCRIPTION
The changes made include:

Adding a constructor to bind the this keyword to the class methods Renaming the handle method to handleAction
Using dispatcher.register instead of dispatcher.subscribe, as subscribe is deprecated Updating the switch statement in handleAction to include a default case for any other action types