### PR TITLE
Fix the dynamic sound and stats command

### DIFF
--- a/bot/src/discord/commands/DynamicSoundCommand.ts
+++ b/bot/src/discord/commands/DynamicSoundCommand.ts
@@ -87,14 +87,14 @@ export class DynamicSoundCommand extends DiscordChatInputCommand {
     let selectedVariant = soundsForSoundCommand[Math.floor(Math.random() * soundsForSoundCommand.length)];
     // Check to see if a sound variant is specified (if it is, set the selected variant to the correct one)
     const variantOption = commandInteraction.options.getInteger('variant', false);
-    if (!variantOption) {
+    if (variantOption !== null) {
       const foundVariant = soundsForSoundCommand.filter((sound) => sound.id === variantOption)[0] || undefined;
       if (foundVariant) {
         selectedVariant = foundVariant;
       }
     }
     // If it is disabled or missing
-    if (!variantOption && variantOption !== selectedVariant.id) {
+    if (variantOption !== null && variantOption !== selectedVariant.id) {
       await commandInteraction.reply({
         content: 'The sound requested was not found.',
         ephemeral: true,

--- a/bot/src/discord/commands/StatsCommand.ts
+++ b/bot/src/discord/commands/StatsCommand.ts
@@ -18,7 +18,7 @@ export class StatsCommand extends DiscordChatInputCommand {
         counter: true,
       },
     });
-    lines.push(`**Global:** ${totalUsages._sum.counter}`);
+    lines.push(`**Global:** ${totalUsages._sum.counter || 0}`);
     if (commandInteraction.inGuild()) {
       const guildUsages = await prismaClient.usage.aggregate({
         _sum: {
@@ -28,7 +28,7 @@ export class StatsCommand extends DiscordChatInputCommand {
           guildId: BigInt(commandInteraction.guildId),
         },
       });
-      lines.push(`**Guild:** ${guildUsages._sum.counter}`);
+      lines.push(`**Guild:** ${guildUsages._sum.counter || 0}`);
     }
     const userUsages = await prismaClient.usage.aggregate({
       _sum: {
@@ -38,7 +38,7 @@ export class StatsCommand extends DiscordChatInputCommand {
         userId: BigInt(commandInteraction.user.id),
       },
     });
-    lines.push(`**You:** ${userUsages._sum.counter}`);
+    lines.push(`**You:** ${userUsages._sum.counter || 0}`);
     await commandInteraction.editReply({
       content: lines.join('\n'),
     });


### PR DESCRIPTION
The dynamic sound command did not work when there was no specific variant specified and the stats command returned null when no usages were found.